### PR TITLE
simple ipc class using message queues

### DIFF
--- a/HeadBoard/IPCQueue/IPCQueue.cpp
+++ b/HeadBoard/IPCQueue/IPCQueue.cpp
@@ -1,0 +1,104 @@
+#include "IPCQueue.h"
+#include <cstddef>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sys/ipc.h>
+#include <sys/msg.h>
+#include <sys/types.h>
+
+namespace fs = std::filesystem;
+using std::cout;
+using std::endl;
+using std::string;
+
+
+/****************************************************************************************************
+* Constructor/Destructor
+****************************************************************************************************/
+
+IPCQueue::IPCQueue(const std::string IPCName)
+{
+	fs::create_directories(QUEUES_DIR);
+	_queueFile = QUEUES_DIR / IPCName;
+	// write/read proj_ids
+	int outID;
+	int inID;
+
+	// if queue already created
+	if(fs::exists(_queueFile))
+	{
+		// cout << "queue file already exists" << endl;
+		_first_instance = false;
+		outID = 1;
+		inID = 0;
+	}
+
+	else
+	{
+		_first_instance = true;
+		// create queue file
+		// cout << "queue file does not exist, creating" << endl;
+		std::ofstream qf(_queueFile);
+		qf << "queue created!" << endl;
+		qf.close();
+		// order swapped compared to existing queue
+		outID = 0;
+		inID = 1;
+	}
+	
+	// create message queues
+	key_t outKey = ftok(_queueFile.c_str(), outID);
+	key_t inKey = ftok(_queueFile.c_str(), inID);
+	_out_qid = msgget(outKey, 0666 | IPC_CREAT);
+	_in_qid = msgget(inKey, 0666 | IPC_CREAT);
+}
+
+
+IPCQueue::~IPCQueue()
+{
+	// first instance gets to clean up
+	if(_first_instance)
+	{
+		cout << "IPCQueue: first instance destroyed, cleaning up" << endl;
+		// destroy queues
+		int out = msgctl(_out_qid, IPC_RMID, NULL);
+		int in = msgctl(_in_qid, IPC_RMID, NULL);
+		// cout << "removed out: " << out << "\nremoved in: " << in << endl;
+		// delete queue file
+		fs::remove(_queueFile);
+	}
+}
+
+
+/****************************************************************************************************
+* Member functions
+****************************************************************************************************/
+
+std::string IPCQueue::read() const
+{
+	QueuedMessage msg;
+	int isMsg = msgrcv(_in_qid, &msg, sizeof(msg), 0, MSG_NOERROR | IPC_NOWAIT);
+
+	// return empty string if there is nothing to read
+	if(isMsg < 0)
+	{
+		return "";
+	}
+
+	return string(msg.message);
+}
+
+
+void IPCQueue::write(std::string command)
+{
+	// prepare message
+	QueuedMessage msg;
+	msg.type = 1;
+	strcpy(msg.message, command.c_str());
+	// send it
+	msgsnd(_out_qid, &msg, sizeof(msg), IPC_NOWAIT);
+}
+
+

--- a/HeadBoard/IPCQueue/IPCQueue.h
+++ b/HeadBoard/IPCQueue/IPCQueue.h
@@ -1,0 +1,33 @@
+#ifndef IPCQUEUE_H
+#define IPCQUEUE_H
+
+#include <string>
+#include <filesystem>
+
+
+class IPCQueue
+{
+	public:
+		IPCQueue(const std::string IPCName);
+		~IPCQueue();
+		std::string read() const;
+		void write(std::string command);
+		// compile time constant, adjust if needed
+		constexpr static long MAX_MESSAGE_LENGTH = 4096;
+
+	protected:
+		// for sending/receiving messages
+		struct QueuedMessage
+		{
+			long type;
+			char message[MAX_MESSAGE_LENGTH];
+		};
+
+		const std::filesystem::path QUEUES_DIR = "/tmp/hoplite/message_queues/";
+		std::filesystem::path _queueFile;
+		int _in_qid;
+		int _out_qid;
+		bool _first_instance = true;
+};
+
+#endif

--- a/HeadBoard/IPCQueue/README.md
+++ b/HeadBoard/IPCQueue/README.md
@@ -1,0 +1,37 @@
+# IPCQueue
+
+A simple to use bidirectional IPC class that uses message queues.
+
+It is meant to provide an asynchronous communication link between 2 classes.
+Queues are identified by name provided in the constructor.
+
+## Usage
+
+```cpp
+// sample code:
+IPCQueue ipcObject("queue_id");
+ipcObject.write("some command");
+string incommingCommand = ipcObject.read();
+```
+
+### Instantiation
+- Provide a name for the the message queue. This is how we link queues together.
+- This is meant for bidirectional behavior only, create more than 2 object that interface with the same queue.
+
+### Writing
+- `write(std::string command)`
+- Will send command to message queue, which can be read by receiving object.
+- This is non-blocking.
+- Commands have a hardcoded character limit, can be read by viewing the `IPCQueue::MAX_MESSAGE_LENGTH` constant.
+
+
+### Reading
+- `read() -> std::string`
+- non-blocking, if no command is present, will return an empty string.
+
+
+## Misc info
+- First object created creates the message queues, and also destroys them.
+	Undefined behavior may result if the first object created is destroyed before the second object is.
+	Therefore, you should always create an IPCQueue object in the parent before creating a child that also uses it.
+	This may be fixed in future version


### PR DESCRIPTION
Added a class to make ipc handling simple. It uses message queues behind the scene and is non-blocking.
Usage information is in the readme.md file in the class directory.
Code was developed on my repo (https://github.com/GreenMoonMan/IPCQueueHandler) and the relevant files were copied here.